### PR TITLE
Update Dockerfile with latest Python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu
 RUN apt-get update
-RUN apt-get -y install python
+RUN apt-get -y install python-is-python3
 COPY hellodevnet.py /hellodevnet.py
 RUN ["chmod", "+x", "/hellodevnet.py"]
 CMD ["/hellodevnet.py"]


### PR DESCRIPTION
"RUN apt-get -y install python" throws the following error during build - "E: Package 'python' has no installation candidate" due to Ubuntu version changes. In order to fix the issue, the python3 package needs to be called.